### PR TITLE
20221007-비밀지도

### DIFF
--- a/week07/비밀지도/java/20221007/src/Solution.java
+++ b/week07/비밀지도/java/20221007/src/Solution.java
@@ -1,0 +1,48 @@
+public class Solution {
+    public String[] solution(int n, int[] arr1, int[] arr2) {
+        String[] secretMap1 = convert10to2(n, arr1);
+        String[] secretMap2 = convert10to2(n, arr2);
+
+        String[] answer = overlap(secretMap1, secretMap2);
+
+        return answer;
+    }
+
+
+    public String[] convert10to2(int n, int[] arr) {
+        String[] convertedArray = new String[n];
+
+        for (int i = 0; i < n; i += 1) {
+            convertedArray[i] = Integer.toBinaryString(arr[i]);
+        }
+
+        for (int i = 0; i < n; i += 1) {
+            while(convertedArray[i].length()<n){
+                convertedArray[i] = "0" + convertedArray[i];
+            }
+        }
+
+        return convertedArray;
+    }
+
+    public String[] overlap(String[] arr1, String[] arr2) {
+        String[] answer = new String[arr1.length];
+        String line = "";
+
+        for (int i = 0; i < arr1.length; i += 1) {
+            for (int j = 0; j < arr1.length; j += 1) {
+                if(arr1[i].charAt(j) == "1".charAt(0) || arr2[i].charAt(j) == "1".charAt(0)){
+                    line += "#";
+                    continue;
+                }
+
+                line += " ";
+            }
+
+            answer[i] = line;
+            line = "";
+        }
+
+        return answer;
+    }
+}

--- a/week07/비밀지도/java/20221007/src/SolutionTest.java
+++ b/week07/비밀지도/java/20221007/src/SolutionTest.java
@@ -1,0 +1,35 @@
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SolutionTest {
+    @Test
+    void convert10to2() {
+        Solution solution = new Solution();
+        int[] arr = new int[]{9, 20, 28, 18, 11};
+
+        String[] converted = solution.convert10to2(5, arr);
+
+        assertEquals("01001", converted[0]);
+        assertEquals("10100", converted[1]);
+        assertEquals("11100", converted[2]);
+        assertEquals("10010", converted[3]);
+        assertEquals("01011", converted[4]);
+    }
+
+    @Test
+    void overlapTwoMap() {
+        Solution solution = new Solution();
+
+        String[] arr1 = new String[]{"01001", "10100", "11100", "10010", "01011"};
+        String[] arr2 = new String[]{"11110", "00001", "10101", "10001", "11100"};
+
+        String[] overlapedArray = solution.overlap(arr1, arr2);
+
+        assertEquals("#####", overlapedArray[0]);
+        assertEquals("# # #", overlapedArray[1]);
+        assertEquals("### #", overlapedArray[2]);
+        assertEquals("#  ##", overlapedArray[3]);
+        assertEquals("#####", overlapedArray[4]);
+    }
+}


### PR DESCRIPTION
문제 설명
비밀지도
네오는 평소 프로도가 비상금을 숨겨놓는 장소를 알려줄 비밀지도를 손에 넣었다. 그런데 이 비밀지도는 숫자로 암호화되어 있어 위치를 확인하기 위해서는 암호를 해독해야 한다. 다행히 지도 암호를 해독할 방법을 적어놓은 메모도 함께 발견했다.

지도는 한 변의 길이가 n인 정사각형 배열 형태로, 각 칸은 "공백"(" ") 또는 "벽"("#") 두 종류로 이루어져 있다.
전체 지도는 두 장의 지도를 겹쳐서 얻을 수 있다. 각각 "지도 1"과 "지도 2"라고 하자. 지도 1 또는 지도 2 중 어느 하나라도 벽인 부분은 전체 지도에서도 벽이다. 지도 1과 지도 2에서 모두 공백인 부분은 전체 지도에서도 공백이다.
"지도 1"과 "지도 2"는 각각 정수 배열로 암호화되어 있다.
암호화된 배열은 지도의 각 가로줄에서 벽 부분을 1, 공백 부분을 0으로 부호화했을 때 얻어지는 이진수에 해당하는 값의 배열이다.
